### PR TITLE
Fix boost::get build error on Ubuntu 16.04

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -287,7 +287,7 @@ Value listunspent(const Array& params, bool fHelp)
         if (pk.IsPayToScriptHash()) {
             CTxDestination address;
             if (ExtractDestination(pk, address)) {
-                const CScriptID& hash = boost::get<const CScriptID&>(address);
+                const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));


### PR DESCRIPTION
I could not build this with ubuntu16.04.

```make
rpcrawtransaction.cpp:299:77:   required from here
/usr/include/boost/variant/get.hpp:178:5: error: invalid application of 'sizeof' to incomplete type 'boost::STATIC_ASSERTION_FAILURE<false>'
     BOOST_STATIC_ASSERT_MSG(
     ^
Makefile:879: recipe for target 'rpcrawtransaction.o' failed
make[3]: *** [rpcrawtransaction.o] Error 1
```

I thought it was the same problem as these and fixed it.
- bitcoin#6113
- dashpay#328

I can build with this fix.